### PR TITLE
изменения в докер-комосе

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,12 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
     depends_on:
-      neo4j:
+      db:
         condition: service_healthy
     networks:
       - neo4j_network
     ports:
-      - "5000:5000"
+      - "127.0.0.1:5000:5000"
 
   frontend:
     build:
@@ -24,17 +24,14 @@ services:
     networks:
       - neo4j_network
     ports:
-      - "3000:5173"
+      - "127.0.0.1:3000:5173"
     depends_on:
       - backend
 
-  neo4j:
-    image: neo4j:latest
+  db:
+    image: neo4j:5.19
     environment:
       - NEO4J_AUTH=${NEO4J_USER}/${NEO4J_PASSWORD}
-    ports:
-      - "7474:7474"  # веб-интерфейс (HTTP)
-      - "7687:7687"  # протокол Bolt для подключения
     volumes:
       - neo4j_data:/data  # сохраняем данные
       - neo4j_logs:/logs  # сохраняем логи


### PR DESCRIPTION
- сервис называется db
- для след итерации рассмотрены ошибки:
"Ошибки по docker compose, которые часто допускают:
1) не выставляйте порт БД наружу ( == сервису db не нужен ports)
2) дополняйте маппинг портов указанием локального интерфейса везде, например '127.0.0.1:8081:8081'
3)не монтируйте локальные каталоги, монтируйте volume (если вам нужны исходники / файлы проекта, то лучше копируйте их на этапе сборки образа)
4)для контейнера СУБД (за исключением memcached и других хранилищ в памяти) обязательно должен использоватся volume, куда будет монитроватся директория с данным СУБД
5) всегда указывайте конкретный тег (версию ) для образов. тег latest указывать нельзя
6) не выносите мапинг портов (ports) в переменные среды - в этом нет необходимости, его вполне можно захардкодить"